### PR TITLE
Split up the functionality of run_pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ The Image De-identification ETL is a WIP tool to assist with reading DICOM image
 - [Getting Started](#getting-started)
   - [Dependencies](#dependencies)
   - [Instructions](#instructions)
-- [Everyday Usage](#everyday-usage)
+- [Example Usage](#example-usage)
+- [Development](#development)
   - [AWS](#aws)
   - [Nix Shell](#nix-shell)
 
@@ -48,19 +49,40 @@ And, voilà, the CLI should fully functional ✨:
 
 ```console
 $ ./image_deid_etl -h
-
-usage: image_deid_etl [-h] {initdb,importuuids,check,run_pipeline} ...
+usage: image_deid_etl [-h] [--program [{cbtn,corsica}]] [--site [SITE]] {initdb,importuuids,check,validate,run,upload2fw,add-fw-metadata,s3-backup-niftis} ...
 
 A WIP tool to assist with reading DICOM images from Orthanc, conversion to anonymized NIfTI images, and uploading to Flywheel.
 
 positional arguments:
-  {initdb,importuuids,check,run_pipeline}
+  {initdb,importuuids,check,validate,run,upload2fw,add-fw-metadata,s3-backup-niftis}
+    validate            check sub/ses mapping
+    run                 download images and run deidentification
+    upload2fw           upload results to Flywheel, when complete
+    add-fw-metadata     add metadata in JSON sidecars to NIfTIs on Flywheel
+    s3-backup-niftis    copies NIfTIs to S3
 
 optional arguments:
   -h, --help            show this help message and exit
+  --program [{cbtn,corsica}]
+                        program namespace (default: cbtn)
+  --site [SITE]         site namespace (default: chop)
 ```
 
-## Everyday Usage
+## Example Usage
+
+To check Orthanc for and process N number of new studies, pipe the output of `check` into the `run` command:
+
+```console
+$ ./image_deid_etl check --limit N --raw | xargs ./image_deid_etl run
+```
+
+To process an individual study, specify an Orthanc UUID after the `run` command:
+
+```console
+$ ./image_deid_etl run UUID
+```
+
+## Development
 
 ### AWS
 

--- a/etl/main_pipeline.py
+++ b/etl/main_pipeline.py
@@ -85,7 +85,7 @@ def validate_info(local_path, program, file_dir):
             sub_list=sub_missing_proj['accession_num'].unique().tolist()
             print('Accessions missing projects '+', '.join(sub_list))
 
-def run_deid(local_path, s3_path, program):
+def run_deid(local_path, program):
     file_dir = local_path+'files/'
     # The "files/" directory path needs to exist, otherwise subject_info will fail to write the csv files. Equivalent
     # to mkdir -p.

--- a/image_deid_etl
+++ b/image_deid_etl
@@ -3,8 +3,9 @@ import argparse
 import json
 import logging.config
 import os
-import shutil
 import sys
+
+from sqlalchemy.exc import IntegrityError
 
 from etl.custom_etl import delete_acquisitions_by_modality, delete_sessions
 from etl.custom_flywheel import inject_sidecar_metadata
@@ -64,148 +65,113 @@ def import_uuids(args) -> int:
 
 
 def check(args) -> int:
-    new_uuids, missing_list, input_df = get_uuids(
-        get_orthanc_url(), get_all_processed_uuids(), "all"
-    )
-    if new_uuids:
-        logger.info("%d new studies found on Orthanc.", len(new_uuids))
+    new_uuids, _, _ = get_uuids(get_orthanc_url(), get_all_processed_uuids(), "all")
 
-        # Useful for local development. Allows you to mark all new studies as
-        # processed, so the ETL doesn't try to process anything.
-        if args.mark_processed:
-            import_uuids_from_set(set(new_uuids))
-            logger.info("Marked %d new studies as \"processed.\"", len(new_uuids))
+    # There is no guarantee that these UUIDs will be in any particular order,
+    # only that they are unprocessed.
+    if args.limit:
+        new_uuids = new_uuids[: args.limit]
+
+    if args.raw:
+        print(*new_uuids, sep="\n")
     else:
-        logger.info("No new UUIDs found on Orthanc")
+        if new_uuids:
+            logger.info("%d new studies found on Orthanc.", len(new_uuids))
+
+            # Useful for local development. Allows you to mark all new studies as
+            # processed, so the ETL doesn't try to process anything.
+            if args.mark_processed:
+                import_uuids_from_set(set(new_uuids))
+                logger.info('Marked %d new studies as "processed."', len(new_uuids))
+        else:
+            logger.info("No new UUIDs found on Orthanc.")
 
     return 0
 
 
-def run_pipeline(args) -> int:
-    s3_path = (
-        "s3://d3b-phi-data-prd/imaging/radiology/"
-        + args.program
-        + "/"
-        + args.site
-        + "/"
-    )
-    local_path = args.program + "/" + args.site
-
-    # ====== validate the inputs ======
-    if local_path[-1:] != "/":
-        local_path = local_path + "/"
-
-    if s3_path[-1:] != "/":
-        s3_path = s3_path + "/"
-
+def validate(args) -> int:
+    local_path = f"{args.program}/{args.site}/"
     file_path = local_path + "files/"
 
-    # validate that we have all the right info/mapping
-    if args.validate:
-        logger.info("Generating subject mapping for validation.")
-        validate_info(local_path, args.program, file_path)
-
-    # run the pipeline
-    if args.run_pipeline:
-        ## ************** download studies from Orthanc **************
-        max_studies = 40
-        logger.info("Checking for new UUIDs.")
-        orthanc_url = get_orthanc_url()
-        new_uuids, missing_list, input_df = get_uuids(
-            orthanc_url, get_all_processed_uuids(), "all"
-        )
-        if len(new_uuids) > max_studies:
-            new_uuids = new_uuids[0 : (max_studies - 1)]
-        ##  ************** if there are new uuids, download & prep files **************
-        if new_uuids:
-            logger.info(
-                "Found new UUID(s) Orthanc, beginning to download %d new studies (max_studies = %d).",
-                len(new_uuids),
-                max_studies,
-            )
-            session_modality_to_skip = ["DX", "US"]  # DX=XR
-            download_unpack_copy(
-                orthanc_url,
-                s3_path,
-                new_uuids,
-                local_path + "DICOMs/",
-                session_modality_to_skip,
-            )
-            ## remove any acquisitions/sessions that we don't want to process
-            delete_acquisitions_by_modality(local_path + "DICOMs/", "OT")
-            delete_acquisitions_by_modality(local_path + "DICOMs/", "SR")
-            delete_sessions(
-                local_path + "DICOMs/", "script"
-            )  # delete any "script" sessions
-            delete_sessions(local_path + "DICOMs/", "Bone Scan")
-            # delete_sessions_by_modality(local_path+'DICOMs/','XR') # delete X-rays
-            # delete_sessions_by_modality(local_path+'DICOMs/','US') # delete ultrasounds
-        else:
-            logger.info("No UUIDs found in Orthanc.")
-
-        logger.info("Commencing de-identification process...")
-        # Run conversion, de-id, quarantine suspicious files, and restructure output for upload.
-        run_deid(local_path, s3_path, args.program)
-
-        logger.info('Uploading "safe" files to Flywheel...')
-        source_path = f"{args.program}/{args.site}/NIfTIs/"
-        for fw_project in next(os.walk(source_path))[1]: # for each project dir
-            proj_path = os.path.join(source_path, fw_project)
-            os.system(
-                f'fw ingest folder --group {FLYWHEEL_GROUP} --project {fw_project} --skip-existing -y --quiet {proj_path}'
-            )
-
-        logger.info("Injecting sidecar metadata...")
-        inject_sidecar_metadata(FLYWHEEL_GROUP, local_path + "NIfTIs/")
-
-        logger.info("Backing up NIfTIs to S3...")
-        os.system("aws s3 sync " + local_path + "NIfTIs/ " + s3_path + "NIfTIs/")
-        logger.info("DONE PROCESSING STUDIES")
-        if os.path.exists(local_path + "NIfTIs_to_check/"):
-            logger.info(
-                "There are files to check in: " + local_path + "NIfTIs_to_check/"
-            )
-            os.system("aws s3 sync " + local_path + "NIfTIs_to_check/ " + s3_path + "NIfTIs_to_check/")
-        if os.path.exists(local_path + "NIfTIs_short_json/"):
-            logger.info(
-                "There are files to check in: " + local_path + "NIfTIs_short_json/"
-            )
-            os.system("aws s3 sync " + local_path + "NIfTIs_short_json/ " + s3_path + "NIfTIs_to_check/")
-
-        logger.info("Updating list of UUIDs...")
-        import_uuids_from_set(set(new_uuids))
-
-    # ====== upload to Flywheel ========================
-    if args.upload2fw:
-        source_path = f"{args.program}/{args.site}/NIfTIs/"
-        for fw_project in next(os.walk(source_path))[1]: # for each project dir
-            proj_path = os.path.join(source_path, fw_project)
-            os.system(
-                f'fw ingest folder --group {FLYWHEEL_GROUP} --project {fw_project} --skip-existing -y --quiet {proj_path}'
-            )
-
-    if args.add_fw_metadata:
-        # assumes local structure == Flywheel structure
-        inject_sidecar_metadata(FLYWHEEL_GROUP, local_path + "NIfTIs/")
-
-    if args.s3_backup_niftis:
-        os.system("aws s3 sync " + local_path + "NIfTIs/ " + s3_path + "NIfTIs/")
-
-    if args.delete_local:
-        if os.path.exists(local_path + "DICOMs/"):
-            shutil.rmtree(local_path + "DICOMs/")
-            logger.info("Deleted from local: " + local_path + "DICOMs/")
-        if os.path.exists(local_path + "NIfTIs/"):
-            shutil.rmtree(local_path + "NIfTIs/")
-            logger.info("Deleted from local: " + local_path + "NIfTIs/")
-        if os.path.exists(local_path + "NIfTIs_short_json/"):
-            shutil.rmtree(local_path + "NIfTIs_short_json/")
-            logger.info("Deleted from local: " + local_path + "NIfTIs_short_json/")
-        if os.path.exists(local_path + "NIfTIs_to_check/"):
-            shutil.rmtree(local_path + "NIfTIs_to_check/")
-            logger.info("Deleted from local: " + local_path + "NIfTIs_to_check/")
+    # Validate that we have all the right info/mapping
+    logger.info("Generating subject mapping for validation.")
+    validate_info(local_path, args.program, file_path)
 
     return 0
+
+
+def run(args) -> int:
+    local_path = f"{args.program}/{args.site}/"
+
+    for uuid in args.uuid:
+        download_unpack_copy(
+            get_orthanc_url(),
+            uuid,
+            local_path + "DICOMs/",
+            args.skip_modalities,
+        )
+
+    # Remove any acquisitions/sessions that we don't want to process.
+    delete_acquisitions_by_modality(local_path + "DICOMs/", "OT")
+    delete_acquisitions_by_modality(local_path + "DICOMs/", "SR")
+
+    # Delete any "script" sessions
+    delete_sessions(local_path + "DICOMs/", "script")
+    delete_sessions(local_path + "DICOMs/", "Bone Scan")
+
+    # Run conversion, de-id, quarantine suspicious files, and restructure output for upload.
+    logger.info("Commencing de-identification process...")
+    run_deid(local_path, args.program)
+
+    logger.info('Uploading "safe" files to Flywheel...')
+    upload2fw(args)
+
+    logger.info("Injecting sidecar metadata...")
+    add_fw_metadata(args)
+
+    logger.info("DONE PROCESSING STUDIES")
+    if os.path.exists(local_path + "NIfTIs_to_check/"):
+        logger.info("There are files to check in: " + local_path + "NIfTIs_to_check/")
+    if os.path.exists(local_path + "NIfTIs_short_json/"):
+        logger.info("There are files to check in: " + local_path + "NIfTIs_short_json/")
+
+    try:
+        logger.info("Updating list of UUIDs...")
+        import_uuids_from_set(args.uuid)
+    except IntegrityError as error:
+        logger.error(
+            "Unable to mark %d UUID(s) as processed. The UUID(s) already exist in the database: %r",
+            len(args.uuid),
+            error,
+        )
+
+    return 0
+
+
+def upload2fw(args) -> int:
+    source_path = f"{args.program}/{args.site}/NIfTIs/"
+    for fw_project in next(os.walk(source_path))[1]:  # for each project dir
+        proj_path = os.path.join(source_path, fw_project)
+        os.system(
+            f"fw ingest folder --group {FLYWHEEL_GROUP} --project {fw_project} --skip-existing -y --quiet {proj_path}"
+        )
+
+    return 0
+
+
+def add_fw_metadata(args) -> int:
+    local_path = f"{args.program}/{args.site}/"
+
+    inject_sidecar_metadata(FLYWHEEL_GROUP, local_path + "NIfTIs/")
+
+    return 0
+
+
+def s3_backup_niftis(args) -> int:
+    local_path = f"{args.program}/{args.site}/"
+    s3_path = f"s3://d3b-phi-data-prd/imaging/radiology/{args.program}/{args.site}/"
+
+    return os.system("aws s3 sync " + local_path + "NIfTIs/ " + s3_path + "NIfTIs/")
 
 
 def main() -> int:
@@ -214,6 +180,19 @@ def main() -> int:
         "images, and uploading to Flywheel.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+    parser.add_argument(
+        "--program",
+        nargs="?",
+        default="cbtn",
+        choices=["cbtn", "corsica"],
+        help="program namespace",
+    )
+    parser.add_argument(
+        "--site",
+        nargs="?",
+        default="chop",
+        help="site namespace",
+    )
     subparsers = parser.add_subparsers()
 
     parser_initdb = subparsers.add_parser("initdb")
@@ -221,67 +200,66 @@ def main() -> int:
 
     parser_import_uuids = subparsers.add_parser("importuuids")
     parser_import_uuids.add_argument(
-        "uuid_file",
+        "file",
         type=argparse.FileType("r"),
-        help="JSON file containing Orthanc UUIDs to process.",
+        help="JSON file containing Orthanc UUIDs to process",
     )
     parser_import_uuids.set_defaults(func=import_uuids)
 
     parser_check = subparsers.add_parser("check")
     parser_check.add_argument(
+        "-l",
+        "--limit",
+        type=int,
+        help="only use the last NUM UUIDs, instead of all UUIDs",
+    )
+    parser_check.add_argument(
         "--mark-processed",
         action="store_true",
-        help="Mark all Orthanc UUIDs found as \"processed.\"",
+        help="mark all Orthanc UUIDs found as processed",
+    )
+    parser_check.add_argument(
+        "-r",
+        "--raw",
+        action="store_true",
+        help="returns a newline-delimited list of unprocessed UUIDs",
     )
     parser_check.set_defaults(func=check)
 
-    parser_run_pipeline = subparsers.add_parser("run_pipeline")
-    parser_run_pipeline.add_argument(
-        "--program",
-        nargs="?",
-        default="cbtn",
-        choices=["cbtn", "corsica"],
-        required=True,
-        help="Program namespace.",
+    parser_validate = subparsers.add_parser("validate", help="check sub/ses mapping")
+    parser_validate.set_defaults(func=validate)
+
+    parser_run = subparsers.add_parser(
+        "run",
+        help="download images and run deidentification",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser_run_pipeline.add_argument(
-        "--site",
-        nargs="?",
-        default="chop",
-        help="Site namespace.",
-        required=True,
+    parser_run.add_argument(
+        "--skip-modalities",
+        nargs="*",
+        default=["DX", "US"],
+        help="space-delimited list of modalities to skip",
     )
-    parser_run_pipeline.add_argument(
-        "--run_pipeline",
-        action="store_true",
-        help='Run the pipeline & upload "safe" files.',
+    parser_run.add_argument(
+        "uuid", nargs="+", help="space-delimited list of UUIDs to process"
     )
-    parser_run_pipeline.add_argument(
-        "--delete_local",
-        action="store_true",
-        help="Delete files off EC2.",
+    parser_run.set_defaults(func=run)
+
+    parser_upload2fw = subparsers.add_parser(
+        "upload2fw",
+        help="upload results to Flywheel, when complete",
     )
-    parser_run_pipeline.add_argument(
-        "--validate",
-        action="store_true",
-        help="Check sub/ses mapping.",
+    parser_upload2fw.set_defaults(func=upload2fw)
+
+    parser_add_fw_metadata = subparsers.add_parser(
+        "add-fw-metadata", help="add metadata in JSON sidecars to NIfTIs on Flywheel"
     )
-    parser_run_pipeline.add_argument(
-        "--upload2fw",
-        action="store_true",
-        help="Upload results to Flywheel, when complete.",
+    parser_add_fw_metadata.set_defaults(func=add_fw_metadata)
+
+    parser_s3_backup_niftis = subparsers.add_parser(
+        "s3-backup-niftis", help="copies NIfTIs to S3"
     )
-    parser_run_pipeline.add_argument(
-        "--add_fw_metadata",
-        action="store_true",
-        help="Add metadata in JSON sidecars to NIfTIs on Flywheel.",
-    )
-    parser_run_pipeline.add_argument(
-        "--s3_backup_niftis",
-        action="store_true",
-        help="Copies NIfTIs to S3.",
-    )
-    parser_run_pipeline.set_defaults(func=run_pipeline)
+    parser_s3_backup_niftis.set_defaults(func=s3_backup_niftis)
 
     args = parser.parse_args()
     args.func(args)

--- a/scripts/test
+++ b/scripts/test
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-./image_deid_etl \
-    run_pipeline \
-    --program cbtn \
-    --site chop \
-    --run_pipeline
+# Look for (in no particular order) and process two studies from Orthanc.
+./image_deid_etl check --limit 2 --raw | xargs ./image_deid_etl run
+
+# Process a specific Orthanc study. This is the study that tripped
+# rordenlab/dcm2niix#566.
+./image_deid_etl run d1b90c78-d9b579f2-a4664679-7ede472b-978d73a2


### PR DESCRIPTION
## Overview

I made the following changes to support the eventual deployment of the ETL on AWS:

- Update `download_unpack_copy` to expect a single UUID as input rather than a list
- Add `--raw` option to the `check` command that prints a newline-delimited list of UUIDs to process
- Separate the validate, upload-to-Flywheel, and backup NIfTI steps into subcommands
- Rename `run_pipeline` command → `run`
- Update `run` to expect a list of UUIDs as input rather than generating the list on its own

Also, I removed the `delete_local` command because the working directories on EC2 will be ephemeral, and it seems simple enough to run `rm -r $your_program_directory` on your local machine.

Resolves #11 

### Checklist

- [x] Squashed any `fixup!` commits
- [x] Updated [README.md](https://github.com/d3b-center/image-deid-etl/blob/develop/README.md) to reflect any changes

### Notes

With the updated interfaces to `check` and `run`, we'll be able to "fan-out" an AWS Batch job by piping the UUID list generated by `check` into `run`. The general shape of this workflow will look like this:

<details>

![Sample Batch Fan](https://docs.aws.amazon.com/step-functions/latest/dg/images/sample-batch-fan.png)

</details>

## Testing Instructions

Look for (in no particular order) and process two studies from Orthanc:

```console
$ ./image_deid_etl check --limit 2 --raw | xargs ./image_deid_etl run
```

**Note:** `xargs` takes each line returned by the `check` command and reshapes it like this:

<details>

```
UUID_1
UUID_2
UUID_3
```

➡️ 

```
./image_deid_etl run UUID_1 UUID_2 UUID_3
```

</details>

I haven't tested the new `validate` or `s3_backup_niftis` subcommands. I feel hazy about their intended usage, so I'd appreciate your help testing them.

Also, I'm not referencing the `test` script in these instructions because I specifically wanted to call out the new commands. But that will work just as well.
