### PR TITLE
Exit if there are no valid DICOMs found

### DIFF
--- a/src/image_deid_etl/image_deid_etl/__main__.py
+++ b/src/image_deid_etl/image_deid_etl/__main__.py
@@ -4,6 +4,7 @@ import logging.config
 import os
 import sys
 import tempfile
+from glob import glob
 
 import boto3
 import flywheel
@@ -211,21 +212,25 @@ def run(args) -> int:
     delete_sessions(local_path + "DICOMs/", "script")
     delete_sessions(local_path + "DICOMs/", "Bone Scan")
 
-    # Run conversion, de-id, quarantine suspicious files, and restructure output for upload.
-    logger.info("Commencing de-identification process...")
-    run_deid(local_path, args.program)
+    # if there are no DICOMs to process, then exit
+    if len(glob(local_path + "DICOMs/*/*")) == 0:
+        logger.info("No DICOMs found. Exiting.")
+    else:
+        # Run conversion, de-id, quarantine suspicious files, and restructure output for upload.
+        logger.info("Commencing de-identification process...")
+        run_deid(local_path, args.program)
 
-    logger.info('Uploading "safe" files to Flywheel...')
-    upload2fw(args)
+        logger.info('Uploading "safe" files to Flywheel...')
+        upload2fw(args)
 
-    logger.info("Injecting sidecar metadata...")
-    add_fw_metadata(args)
+        logger.info("Injecting sidecar metadata...")
+        add_fw_metadata(args)
 
-    logger.info("DONE PROCESSING STUDIES")
-    if os.path.exists(local_path + "NIfTIs_to_check/"):
-        logger.info("There are files to check in: " + local_path + "NIfTIs_to_check/")
-    if os.path.exists(local_path + "NIfTIs_short_json/"):
-        logger.info("There are files to check in: " + local_path + "NIfTIs_short_json/")
+        logger.info("DONE PROCESSING STUDIES")
+        if os.path.exists(local_path + "NIfTIs_to_check/"):
+            logger.info("There are files to check in: " + local_path + "NIfTIs_to_check/")
+        if os.path.exists(local_path + "NIfTIs_short_json/"):
+            logger.info("There are files to check in: " + local_path + "NIfTIs_short_json/")
 
     try:
         logger.info("Updating list of UUIDs...")


### PR DESCRIPTION
## Overview

Some studies only contain DICOMs of no-interest, these files are deleted prior to the main processes but causes those to error because, no files remain to be processed. This PR adds a catch prior to running the main ETL to see if there are any DICOM files to-be-processed. If not, the uuid is still added to the database prior to exiting.

Resolves #43 

## Testing Instructions

After following the main setup instructions in the README:

`image-deid-etl run 9f186afd-46b7d9d0-6ff63879-0c87ab08-e72194c3`
