### PR TITLE
Add Step Functions workflow that wraps the ETL

### DIFF
--- a/deployment/terraform/job-definitions/image-deid-etl.json.tmpl
+++ b/deployment/terraform/job-definitions/image-deid-etl.json.tmpl
@@ -2,6 +2,11 @@
     "image": "${image_url}",
     "vcpus": ${image_deid_etl_vcpus},
     "memory": ${image_deid_etl_memory},
+    "command": [
+       "image-deid-etl",
+       "run",
+       "Ref::study-uuid"
+    ],
     "environment": [
         {
           "name": "DATABASE_URL",

--- a/deployment/terraform/sfn.tf
+++ b/deployment/terraform/sfn.tf
@@ -1,0 +1,18 @@
+
+#
+# Step Functions resources
+#
+resource "aws_sfn_state_machine" "default" {
+  name     = "stateMachine${local.short}"
+  role_arn = aws_iam_role.step_functions_service_role.arn
+
+  definition = templatefile("${path.module}/step-functions/image-deid-etl.json.tmpl", {
+    batch_job_definition_arn = aws_batch_job_definition.default.arn
+    batch_job_queue_arn      = aws_batch_job_queue.default.arn
+  })
+
+  tags = {
+    Project     = var.project
+    Environment = var.environment
+  }
+}

--- a/deployment/terraform/step-functions/image-deid-etl.json.tmpl
+++ b/deployment/terraform/step-functions/image-deid-etl.json.tmpl
@@ -1,0 +1,33 @@
+{
+    "StartAt": "Fan out batch jobs",
+    "TimeoutSeconds": 3600,
+    "States": {
+        "Fan out batch jobs": {
+            "Type": "Map",
+            "End": true,
+            "ItemsPath": "$.study-uuids",
+            "Parameters": {
+                "FormattedJobName.$": "States.Format('ProcessStudy_{}', $$.Map.Item.Value)",
+                "StudyUuid.$": "$$.Map.Item.Value"
+            },
+            "Iterator": {
+                "StartAt": "Submit Batch Job",
+                "States": {
+                    "Submit Batch Job": {
+                        "Type": "Task",
+                        "Resource": "arn:aws:states:::batch:submitJob.sync",
+                        "Parameters": {
+                            "JobName.$": "$.FormattedJobName",
+                            "JobQueue": "${batch_job_queue_arn}",
+                            "JobDefinition": "${batch_job_definition_arn}",
+                            "Parameters": {
+                                "study-uuid.$": "$.StudyUuid"
+                            }
+                        },
+                        "End": true
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Step Functions is a managed orchestration service that lets you chain together different AWS services to create multi-step workflows. I designed a Step Functions workflow that takes a list of study UUIDs as input, iterates over each UUID, and submits a Batch job.

Resolves #8 

### Checklist

- [ ] Squashed any `fixup!` commits
- [ ] Updated [README.md](https://github.com/d3b-center/image-deid-etl/blob/develop/README.md) to reflect any changes

### Notes

I originally planned to include the mechanism that'd generate the input list (e.g., `image-deid-etl check`) as part of this pull request, but I decided to hold off and split that into its own effort (in #55  and #56).

## Testing Instructions


Make sure your AWS SSO session is current:

```console
$ export AWS_PROFILE=chopd3bprod
$ aws sso login
```

Launch an instance of the included Terraform container image:

```console
$ docker-compose -f docker-compose.ci.yml run --rm terraform
bash-5.1#
```

Once inside the context of the container image, set `GIT_COMMIT` to `9c9b530` (I already published this tag):

```console
bash-5.1# export GIT_COMMIT=9c9b530
```

Use `infra` to generate and apply a Terraform plan:

```console
bash-5.1# ./scripts/infra plan
bash-5.1# ./scripts/infra apply
```

Navigate to the [stateMachineImageDeidEtl](https://us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/statemachines/view/arn:aws:states:us-east-1:515011955314:stateMachine:stateMachineImageDeidEtl) state machine in the AWS Console. Then, select **Start execution**, and use the following JSON as input:

```json
{
  "study-uuids": [
    "e9ab1dcd-6e3360c1-a9f6b1bf-921abcb1-94d8e8ad",
    "617b818c-5bd2aa09-4f5eed6a-32a627c8-f89454a2",
    "d93cb734-89799f7d-c670597a-7ca842b9-6066987a",
    "32ceb627-98da2d0b-8bf01652-7fd38818-5e60f4d7"
  ]
}
```

The `study-uuids` array contains all of the Orthanc Study UUIDs we'd like the workflow to process.

From the **Execution event history**, you can navigate to the Batch jobs that the workflow spun off and view their Cloudwatch log output. 

**Note:** Right now, it appears that some of these study UUIDs are failing due to a JSON decoding error parsing the Orthanc response.

