### PR TITLE
Add flag to disable audit logs in fw ingest folder

### DIFF
--- a/src/image_deid_etl/image_deid_etl/__main__.py
+++ b/src/image_deid_etl/image_deid_etl/__main__.py
@@ -268,7 +268,7 @@ def upload2fw(args) -> int:
         for fw_project in next(os.walk(source_path))[1]:  # for each project dir
             proj_path = os.path.join(source_path, fw_project)
             os.system(
-                f"fw ingest folder --group {FLYWHEEL_GROUP} --project {fw_project} --skip-existing -y --quiet {proj_path}"
+                f"fw ingest folder --no-audit-log --group {FLYWHEEL_GROUP} --project {fw_project} --skip-existing -y --quiet {proj_path}"
             )
     return 0
 


### PR DESCRIPTION
## Overview

Each session is uploaded using `fw ingest folder` which by default creates an audit log CSV file (attached to the project container on Flywheel) for each upload. Because we had hundreds of such uploads in some projects, this was causing performance issues that would manifest in things like project-level queries (with DataViews). Flywheel support folks zipped all existing CSVs into a single CSV within each project, which addressed the performance instability.

To avoid this in the future, I've added a `--no-audit-log` option to the upload command so that no such CSVs will be created. 

Closes #54 

### Notes

These audit logs are not currently used and are not very informative. Moreover, the information they contain can be generated retrospectively.

## Testing Instructions

* Follow README instructions to instantiate and update console
* Run `image-deid-etl run [uuid]` with your choice of UUID
