### PR TITLE
Add workflow trigger for manual deployment

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
   pull_request:
+  workflow_dispatch:
 
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:


### PR DESCRIPTION
## Overview

I added the `workflow_dispatch` trigger to the existing workflow `continuous_integration.yaml` file to allow a user to manually execute the workflow from the UI, API, or CLI. Previously it was only set to trigger on push to develop branch upon merging a PR.

[General documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)