### PR TITLE
handle sessions with no DICOMs to process

### DIFF
--- a/src/image_deid_etl/image_deid_etl/__main__.py
+++ b/src/image_deid_etl/image_deid_etl/__main__.py
@@ -207,27 +207,31 @@ def run(args) -> int:
     # Remove any acquisitions/sessions that we don't want to process.
     delete_acquisitions_by_modality(local_path + "DICOMs/", "OT")
     delete_acquisitions_by_modality(local_path + "DICOMs/", "SR")
+    delete_acquisitions_by_modality(local_path + "DICOMs/", "XA") # X-Ray Angiography
+    delete_acquisitions_by_modality(local_path + "DICOMs/", "US") # ultrasound
 
     # Delete any "script" sessions
     delete_sessions(local_path + "DICOMs/", "script")
     delete_sessions(local_path + "DICOMs/", "Bone Scan")
 
     # if there are no DICOMs to process, then exit
-    if len(glob(local_path + "DICOMs/*/*")) == 0:
-        logger.info("No DICOMs found. Exiting.")
+    if len(glob(local_path + "DICOMs/*/*/*")) == 0: # checks if there are any acquisition dir's
+        logger.info(f"'No DICOMs found. Exiting.") # if there are no valid DICOMs to proces, then exit (still add the uuid to the RDS)
     else:
         # Run conversion, de-id, quarantine suspicious files, and restructure output for upload.
         logger.info("Commencing de-identification process...")
-        missing_ses_flag,missing_subj_id_flag = run_deid(local_path, args.program)
+        missing_ses_flag, missing_subj_id_flag = run_deid(local_path, args.program)
 
         if missing_ses_flag:
             raise FileNotFoundError(
-                "Unable to generate session label."
+                "Unable to generate session label. Exiting."
                 )
+            sys.exit(1)
         if missing_subj_id_flag:
             raise FileNotFoundError(
-                "Unable to find subject ID."
+                "Unable to find subject ID. Exiting."
             )
+            sys.exit(1)
         else:
             logger.info('Uploading "safe" files to Flywheel...')
             upload2fw(args)
@@ -241,15 +245,15 @@ def run(args) -> int:
             if os.path.exists(local_path + "NIfTIs_short_json/"):
                 logger.info("There are files to check in: " + local_path + "NIfTIs_short_json/")
 
-            try:
-                logger.info("Updating list of UUIDs...")
-                import_uuids_from_set(args.uuid)
-            except IntegrityError as error:
-                logger.error(
-                    "Unable to mark %d UUID(s) as processed. The UUID(s) already exist in the database: %r",
-                    len(args.uuid),
-                    error,
-                )
+    try:
+        logger.info("Updating list of UUIDs...")
+        import_uuids_from_set(args.uuid)
+    except IntegrityError as error:
+        logger.error(
+            "Unable to mark %d UUID(s) as processed. The UUID(s) already exist in the database: %r",
+            len(args.uuid),
+            error,
+        )
 
     return 0
 


### PR DESCRIPTION
## Overview

Some sessions were throwing errors because there were no valid DICOMs to process (uuid = 82ed277a-69202308-ec85c7f8-8c1dd143-684cb136). To avoid this - after extracting the DICOM zip and deleting modalities of non-interest, I added a catch for empty DICOM directories.

Additionally I added two modality types to skip processing (XR & US).