### PR TITLE
Handle broken DICOMS due to JPEG2000 compression

### DIFF
--- a/src/image_deid_etl/Dockerfile
+++ b/src/image_deid_etl/Dockerfile
@@ -14,10 +14,8 @@ RUN set -ex \
 #  ========= config dcm2niix =====================
 FROM debian:bullseye-slim AS dcm2niix-builder
 
-# We need to build our own version of dcm2niix because there hasn't been a
-# release since @neurolabusc fixed
-# https://github.com/rordenlab/dcm2niix/issues/566.
-#ENV DCM2NIIX_VERSION="002ebcdb9b2a87de7b883e9ddada3963a1cc2327"
+# Specify version of dcm2niix release
+ENV DCM2NIIX_VERSION="bb3a6c35d2bbac6ed95acb2cd0df65f35e79b5fb"
 
 RUN mkdir -p /usr/local/src
 WORKDIR /usr/local/src
@@ -27,6 +25,7 @@ RUN set -ex \
     # The external CMake projects are referenced with the deprecated git:// protocol.
     && git config --global url."https://".insteadOf git:// \
     && git clone https://github.com/rordenlab/dcm2niix.git && cd dcm2niix \
+    && git checkout "$DCM2NIIX_VERSION" \
     && mkdir build && cd build  \
     && cmake -DBATCH_VERSION=OFF -DUSE_OPENJPEG=ON -DUSE_JPEGLS=true -DZLIB_IMPLEMENTATION=Cloudflare ..  && make
 

--- a/src/image_deid_etl/Dockerfile
+++ b/src/image_deid_etl/Dockerfile
@@ -1,3 +1,4 @@
+# ========= config AWS CLI ======================
 FROM debian:bullseye-slim AS awscli2-builder
 
 RUN set -ex \
@@ -10,12 +11,13 @@ RUN set -ex \
     # present in /usr/local/bin of the installer stage.
     && ./aws/install --bin-dir /aws-cli-bin/
 
+#  ========= config dcm2niix =====================
 FROM debian:bullseye-slim AS dcm2niix-builder
 
 # We need to build our own version of dcm2niix because there hasn't been a
 # release since @neurolabusc fixed
 # https://github.com/rordenlab/dcm2niix/issues/566.
-ENV DCM2NIIX_VERSION="002ebcdb9b2a87de7b883e9ddada3963a1cc2327"
+#ENV DCM2NIIX_VERSION="002ebcdb9b2a87de7b883e9ddada3963a1cc2327"
 
 RUN mkdir -p /usr/local/src
 WORKDIR /usr/local/src
@@ -25,9 +27,20 @@ RUN set -ex \
     # The external CMake projects are referenced with the deprecated git:// protocol.
     && git config --global url."https://".insteadOf git:// \
     && git clone https://github.com/rordenlab/dcm2niix.git && cd dcm2niix \
-    && git checkout "$DCM2NIIX_VERSION" \
     && mkdir build && cd build  \
     && cmake -DBATCH_VERSION=OFF -DUSE_OPENJPEG=ON -DUSE_JPEGLS=true -DZLIB_IMPLEMENTATION=Cloudflare ..  && make
+
+#  ========= config libdcm-tools (GDCM utility package) =====================
+FROM ubuntu:focal AS gdcm-builder
+
+RUN mkdir -p /usr/local/src
+WORKDIR /usr/local/src
+
+RUN apt-get update && apt-get install -y libgdcm-tools \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# ========= config Flywheel CLI =====================
 
 FROM debian:bullseye-slim AS flywheel-cli-builder
 
@@ -40,6 +53,8 @@ RUN set -ex \
     && apt-get update && apt-get install -y ca-certificates curl unzip --no-install-recommends \
     && curl "https://storage.googleapis.com/flywheel-dist/cli/$FLYWHEEL_VERSION/fw-linux_amd64-$FLYWHEEL_VERSION.zip" -o "flywheel-cli.zip" \
     && unzip flywheel-cli.zip
+
+# ========= config Python packages =====================
 
 FROM python:3.9-slim-bullseye
 
@@ -67,6 +82,8 @@ RUN set -ex \
     && apt-get purge -y --auto-remove $buildDeps \
     && rm -rf /var/lib/apt/lists/*
 
+# ========= finalize =====================
+
 COPY . /usr/local/src/
 
 RUN set -ex \
@@ -82,3 +99,6 @@ COPY --from=awscli2-builder /aws-cli-bin/ /usr/local/bin/
 COPY --from=dcm2niix-builder /usr/local/src/dcm2niix/build/bin/dcm2niix /usr/local/bin/dcm2niix
 # Install the Flywheel CLI.
 COPY --from=flywheel-cli-builder /usr/local/src/linux_amd64/fw /usr/local/bin/fw
+# Install GDCM package libdcm-tools.
+COPY --from=gdcm-builder /usr/bin/ /usr/local/bin/
+COPY --from=gdcm-builder /lib/x86_64-linux-gnu/ /lib/x86_64-linux-gnu/

--- a/src/image_deid_etl/image_deid_etl/custom_etl.py
+++ b/src/image_deid_etl/image_deid_etl/custom_etl.py
@@ -389,8 +389,8 @@ def convert_dicom2nifti(data_dir):
             # (this should handle errors with JPEG2000 compression in OpenJPEG within dcm2niix)
             exit_code = os.popen('echo $?').readlines()[0].strip('\n')
             if (glob(acquisition+'/*.nii.gz')==[]) or (exit_code != '0'): 
-                for file_path in glob(acquisition+'/*.dcm'):
-                    os.system(f'gdcmconv -w "{file_path}" "{file_path}"  ')
+                for file_path in glob(acquisition+'/*.dcm'): # for each DICOM file
+                    os.system(f'gdcmconv -w "{file_path}" "{file_path}"  ') # -w flag for decompression
                 os.system('dcm2niix -w 1 -b y -ba y -f ''"%d"'' -p y -z y -v 0 ''"'+acquisition+'"'' ') # now re-try the conversion
             # add voxel dimensions to sidecar
             if glob(acquisition+'/*.nii.gz'): # if there are NIfTIs for this acquisition


### PR DESCRIPTION
## Overview

For all acquisitions in some studies, or even for a subset of acquisitions in a given study, `OpenJPEG` was failing to decode certain DICOMs in the `dcm2niix` program, such as:

```
Chris Rorden's dcm2niiX version v1.0.20220720  (JP2:OpenJPEG) (JP-LS:CharLS) GCC10.2.1 x86-64 (64-bit Linux)
Found 3 DICOM file(s)
Image Decompression is new: please validate conversions
Error: OpenJPEG j2k_to_image failed to decode ./MR000000.dcm
Error: OpenJPEG j2k_to_image failed to decode ./MR000001.dcm
Error: OpenJPEG j2k_to_image failed to decode ./MR000002.dcm
```

This was found to be due to (lossless) JPEG2000 compressed DICOMs, which is not common and not well supported. This error has been seen in other's use of `dcm2niix` previously (as described in #60 ) and was supposed to be addressed in a following release.

To address this I chose to use the GDCM program `gdcmconv` which converts DICOM to DICOM, and can convert broken DICOM into parsable DICOM, with the `-w` (decompress) option.

For any acquisition for which a first pass of `dcm2niix` produces a non-zero error code, or does not produce nifti files as output, performs `gdcmconv` on each DICOM in the acquisition and then re-runs `dcm2niix`.

I also updated `dcm2niix` to the most recent (stable) release.

Closes #60 

## Testing Instructions

* uuid of study with all corrupt images: c8b87d95-5d8baf72-42a5ed27-4a46f1c3-de5693ab
* uuid of study with some corrupt images: 6570c29f-b7aa6541-899a1498-b194a15c-e4b4dab5

