### PR TITLE
Update custom_flywheel.py

### DIFF
--- a/src/image_deid_etl/image_deid_etl/custom_flywheel.py
+++ b/src/image_deid_etl/image_deid_etl/custom_flywheel.py
@@ -20,7 +20,7 @@ def confirm_proj_exists(fw_client: flywheel.Client, flywheel_group: str, data_di
             logger.info(f'Creating new Flywheel project:{fw_proj_label}')
             group = fw_client.get(flywheel_group)
             project = group.add_project(label = fw_proj_label)
-            project_id = project['id']
+            project_id = project['_id']
             existing_perms = project['permissions']
             existing_usrs = []
             for perm in existing_perms:


### PR DESCRIPTION
## Overview

The Flywheel SDK returned dictionaries for each container have an 'id' key that appears to be labelled 'id' but in fact is '_id'. Updating one line in `confirm_proj_exists` in `custom_flywheel.py` to update this:

project_dict['id'] > project_dict['_id']