### PR TITLE
📌 Update rollbar/github-deploy-action 2.1.1 -> 2.1.2

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -44,7 +44,7 @@ jobs:
         if: github.ref == 'refs/heads/develop'
 
       - name: Notify Rollbar
-        uses: rollbar/github-deploy-action@2.1.1
+        uses: rollbar/github-deploy-action@2.1.2
         with:
           environment: 'staging'
           version: ${{ github.sha }}

--- a/.github/workflows/continuous_integration_manual.yml
+++ b/.github/workflows/continuous_integration_manual.yml
@@ -42,7 +42,7 @@ jobs:
         if: github.ref == 'refs/heads/develop'
 
       - name: Notify Rollbar
-        uses: rollbar/github-deploy-action@2.1.1
+        uses: rollbar/github-deploy-action@2.1.2
         with:
           environment: 'staging'
           version: ${{ github.sha }}


### PR DESCRIPTION
## Overview

Updating Rollbar github action to remove the deprecated set-output command.

Connects [AD-856](https://d3b.atlassian.net/browse/AD-856)

### Checklist

- [x] Squashed any `fixup!` commits
- [x] Updated [README.md](https://github.com/d3b-center/image-deid-etl/blob/develop/README.md) to reflect any changes

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output


[AD-856]: https://d3b.atlassian.net/browse/AD-856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ