### PR TITLE
Bump RDS engine 14.11 -> 14.12

### DIFF
--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -95,7 +95,7 @@ variable "rds_allocated_storage" {
 
 variable "rds_engine_version" {
   type    = string
-  default = "14.11"
+  default = "14.12"
 }
 
 variable "rds_parameter_group_family" {


### PR DESCRIPTION
## Overview

Bump RDS Postgres engine version from 14.11 -> 14.12

Connects #XXX

### Checklist

- [x] Squashed any `fixup!` commits
- [x] Updated [README.md](https://github.com/d3b-center/image-deid-etl/blob/develop/README.md) to reflect any changes
